### PR TITLE
Use server-side time for starting, stopping and updating timers.

### DIFF
--- a/src/time_tracker/timers/pubsub/commands.clj
+++ b/src/time_tracker/timers/pubsub/commands.clj
@@ -51,13 +51,13 @@
                        :id   timer-id})
     (io/send-error! channel "Could not delete timer")))
 
-(defn update-timer!
-  [channel google-id connection {:keys [timer-id duration current-time notes] :as args}]
+(defn update-timer-now!
+  [channel google-id connection {:keys [timer-id duration notes] :as args}]
   (if-let [updated-timer
            (timers-db/update! connection
                                        timer-id
                                        duration
-                                       current-time
+                                       (util/current-epoch-seconds)
                                        notes)]
     (io/broadcast-state-change! google-id updated-timer :update)
     (io/send-error! channel "Could not update duration")))

--- a/src/time_tracker/timers/pubsub/commands.clj
+++ b/src/time_tracker/timers/pubsub/commands.clj
@@ -36,8 +36,8 @@
                           :stop-time started-time}))))
     (io/send-error! channel "Could not start timer")))
 
-(defn create-and-start-timer!
-  [channel google-id connection {:keys [project-id started-time created-time notes] :as args}]
+(defn create-and-start-timer-now!
+  [channel google-id connection {:keys [project-id created-time notes] :as args}]
   (let [created-timer (timers-db/create! connection project-id google-id created-time notes)]
     (io/broadcast-state-change! google-id created-timer :create)
     (start-timer-now! channel google-id connection

--- a/src/time_tracker/timers/pubsub/commands.clj
+++ b/src/time_tracker/timers/pubsub/commands.clj
@@ -14,10 +14,10 @@
 ;; Every message pushed from the server should have a :type field, and other args
 ;; as necessary.
 
-(defn stop-timer!
-  [channel google-id connection {:keys [timer-id stop-time] :as args}]
+(defn stop-timer-now!
+  [channel google-id connection {:keys [timer-id] :as args}]
   (if-let [stopped-timer (timers-db/stop!
-                          connection timer-id stop-time)]
+                          connection timer-id (util/current-epoch-seconds))]
     (io/broadcast-state-change! google-id stopped-timer :update)
     (io/send-error! channel "Could not stop timer")))
 
@@ -31,9 +31,8 @@
               timers-to-stop (filter #(not= (:id %) timer-id)
                                      started-timers)]
           (doseq [timer timers-to-stop]
-            (stop-timer! channel google-id connection
-                         {:timer-id  (:id timer)
-                          :stop-time started-time}))))
+            (stop-timer-now! channel google-id connection
+                             {:timer-id  (:id timer)}))))
     (io/send-error! channel "Could not start timer")))
 
 (defn create-and-start-timer-now!

--- a/src/time_tracker/timers/pubsub/routes.clj
+++ b/src/time_tracker/timers/pubsub/routes.clj
@@ -19,7 +19,7 @@
                                         (middleware/wrap-validator
                                          ::pubsub-spec/create-and-start-timer-args))}
 
-          {"start-timer"            (-> commands/start-timer!
+          {"start-timer"            (-> commands/start-timer-now!
                                         (middleware/wrap-owns-timer)
                                         (middleware/wrap-validator ::pubsub-spec/start-timer-args))
            "stop-timer"             (-> commands/stop-timer!

--- a/src/time_tracker/timers/pubsub/routes.clj
+++ b/src/time_tracker/timers/pubsub/routes.clj
@@ -14,7 +14,7 @@
 (def command-map
   (wrap-middlewares
    [middleware/wrap-exception middleware/wrap-transaction]
-   (merge {"create-and-start-timer" (-> commands/create-and-start-timer!
+   (merge {"create-and-start-timer" (-> commands/create-and-start-timer-now!
                                         ;;(middleware/wrap-can-create-timer)
                                         (middleware/wrap-validator
                                          ::pubsub-spec/create-and-start-timer-args))}

--- a/src/time_tracker/timers/pubsub/routes.clj
+++ b/src/time_tracker/timers/pubsub/routes.clj
@@ -28,8 +28,8 @@
            "delete-timer"           (-> commands/delete-timer!
                                         (middleware/wrap-owns-timer)
                                         (middleware/wrap-validator ::pubsub-spec/delete-timer-args))
-           "update-timer"           (-> commands/update-timer!
+           "update-timer"           (-> commands/update-timer-now!
                                         (middleware/wrap-owns-timer)
                                         (middleware/wrap-validator
-                                         ::pubsub-spec/update-timer-args))
+                                         ::pubsub-spec/update-timer-now-args))
            "ping"                   commands/receive-ping!})))

--- a/src/time_tracker/timers/pubsub/routes.clj
+++ b/src/time_tracker/timers/pubsub/routes.clj
@@ -17,14 +17,14 @@
    (merge {"create-and-start-timer" (-> commands/create-and-start-timer-now!
                                         ;;(middleware/wrap-can-create-timer)
                                         (middleware/wrap-validator
-                                         ::pubsub-spec/create-and-start-timer-args))}
+                                         ::pubsub-spec/create-and-start-timer-now-args))}
 
           {"start-timer"            (-> commands/start-timer-now!
                                         (middleware/wrap-owns-timer)
-                                        (middleware/wrap-validator ::pubsub-spec/start-timer-args))
-           "stop-timer"             (-> commands/stop-timer!
+                                        (middleware/wrap-validator ::pubsub-spec/start-timer-now-args))
+           "stop-timer"             (-> commands/stop-timer-now!
                                         (middleware/wrap-owns-timer)
-                                        (middleware/wrap-validator ::pubsub-spec/stop-timer-args))
+                                        (middleware/wrap-validator ::pubsub-spec/stop-timer-now-args))
            "delete-timer"           (-> commands/delete-timer!
                                         (middleware/wrap-owns-timer)
                                         (middleware/wrap-validator ::pubsub-spec/delete-timer-args))

--- a/src/time_tracker/timers/pubsub/spec.clj
+++ b/src/time_tracker/timers/pubsub/spec.clj
@@ -10,19 +10,17 @@
 (s/def ::stop-time ::core-spec/epoch)
 (s/def ::notes ::timers-spec/notes)
 
-(s/def ::start-timer-args
-  (s/keys :req-un [::timer-id ::started-time]))
+(s/def ::start-timer-now-args
+  (s/keys :req-un [::timer-id]))
 
-(s/def ::stop-timer-args
-  (s/keys :req-un [::timer-id ::stop-time]))
+(s/def ::stop-timer-now-args
+  (s/keys :req-un [::timer-id]))
 
 (s/def ::delete-timer-args
   (s/keys :req-un [::timer-id]))
 
-(s/def ::create-and-start-timer-args
-  (s/keys :req-un [::timers-spec/project-id ::started-time ::created-time ::notes]))
+(s/def ::create-and-start-timer-now-args
+  (s/keys :req-un [::timers-spec/project-id ::created-time ::notes]))
 
 (s/def ::update-timer-args
   (s/keys :req-un [::timer-id ::timers-spec/duration ::current-time ::notes]))
-
-

--- a/src/time_tracker/timers/pubsub/spec.clj
+++ b/src/time_tracker/timers/pubsub/spec.clj
@@ -4,9 +4,7 @@
             [time-tracker.timers.spec :as timers-spec]))
 
 (s/def ::timer-id ::timers-spec/id)
-(s/def ::started-time ::timers-spec/started-time-not-nilable)
 (s/def ::created-time ::timers-spec/time-created)
-(s/def ::current-time ::core-spec/epoch)
 (s/def ::stop-time ::core-spec/epoch)
 (s/def ::notes ::timers-spec/notes)
 
@@ -22,5 +20,5 @@
 (s/def ::create-and-start-timer-now-args
   (s/keys :req-un [::timers-spec/project-id ::created-time ::notes]))
 
-(s/def ::update-timer-args
-  (s/keys :req-un [::timer-id ::timers-spec/duration ::current-time ::notes]))
+(s/def ::update-timer-now-args
+  (s/keys :req-un [::timer-id ::timers-spec/duration ::notes]))

--- a/test/time_tracker/timers/pubsub_test.clj
+++ b/test/time_tracker/timers/pubsub_test.clj
@@ -217,20 +217,17 @@
                                                   "gid2"
                                                   current-time
                                                   "wool heater")
-        [response-chan socket] (test-helpers/make-ws-connection "gid1")
-        update-time            (+ current-time 17)]
+        [response-chan socket] (test-helpers/make-ws-connection "gid1")]
     (try
       (testing "Owned timer"
         (timers-db/start! (db/connection) (:id timer1) current-time)
         (ws/send-msg socket (json/encode
                              {:command      "update-timer"
                               :timer-id     (:id timer1)
-                              :current-time update-time
                               :duration     37
                               :notes        "brotherhood of the snake"}))
         (let [command-response (test-helpers/try-take!! response-chan)]
           (is (= (:id timer1) (:id command-response)))
-          (is (= update-time (:started-time command-response)))
           (is (= 37
                  (:duration command-response)))
           (is (= "brotherhood of the snake"
@@ -242,7 +239,6 @@
         (ws/send-msg socket (json/encode
                              {:command      "update-timer"
                               :timer-id     (:id timer2)
-                              :current-time update-time
                               :duration     37
                               :notes        "baz"}))
         (let [command-response (test-helpers/try-take!! response-chan)]

--- a/test/time_tracker/timers/pubsub_test.clj
+++ b/test/time_tracker/timers/pubsub_test.clj
@@ -63,7 +63,7 @@
           (is (= (:id timer1) (:id stop-response)))
           (is (not (nil? :started-time )))
           (is (nil? (:started-time stop-response)))))
-      
+
       (finally (ws/close socket)))))
 
 (deftest stop-timer-command-test
@@ -80,7 +80,6 @@
                                                   "gid2"
                                                   current-time
                                                   "")
-        stop-time              (+ current-time 7)
         [response-chan socket] (test-helpers/make-ws-connection "gid1")]
     (timers-db/start! (db/connection) (:id timer1) current-time)
     (timers-db/start! (db/connection) (:id timer2) current-time)
@@ -88,18 +87,14 @@
       (testing "Owned timer"
         (ws/send-msg socket (json/encode
                              {:command   "stop-timer"
-                              :timer-id  (:id timer1)
-                              :stop-time stop-time}))
+                              :timer-id  (:id timer1)}))
         (let [command-response (test-helpers/try-take!! response-chan)]
-          (is (s/valid? ::timers-spec/duration (:duration command-response)))
-          (is (= 7
-                 (:duration command-response)))))
+          (is (s/valid? ::timers-spec/duration (:duration command-response)))))
 
       (testing "Unowned timer"
         (ws/send-msg socket (json/encode
                              {:command   "stop-timer"
-                              :timer-id  (:id timer2)
-                              :stop-time stop-time}))
+                              :timer-id  (:id timer2)}))
         (let [command-response (test-helpers/try-take!! response-chan)]
           (is (:error command-response))))
       (finally (ws/close socket)))))
@@ -143,7 +138,7 @@
                               :timer-id  (:id timer2)}))
         (let [command-response (test-helpers/try-take!! response-chan)]
           (is (:error command-response))))
-      
+
       (finally (ws/close socket)))))
 
 (deftest create-and-start-timer-command-test
@@ -205,7 +200,7 @@
                                 :notes        "robin hood in reverse"}))
           (let [command-response (test-helpers/try-take!! response-chan)]
             (is (:error command-response))))
-      
+
       (finally (ws/close socket)))))
 
 (deftest update-timer-command-test
@@ -264,7 +259,7 @@
                              {:command "ping"}))
         (let [response (test-helpers/try-take!! response-chan)]
           (is (= "pong" (:type response)))))
-      
+
       (finally (ws/close socket)))))
 
 
@@ -295,7 +290,7 @@
                          (async/timeout 100) ::not-received)]
           (is (= ::not-received
                  result3))))
-      
+
       (finally
         (ws/close socket1)
         (ws/close socket2)


### PR DESCRIPTION
For the pubsub commands, use server-side time instead of client-side time. Closes #58.