### PR TITLE
Dropping timeout from tests

### DIFF
--- a/test/time_tracker/test_helpers.clj
+++ b/test/time_tracker/test_helpers.clj
@@ -30,9 +30,7 @@
 
 (defn try-take!!
   [channel]
-  (alt!!
-    channel              ([value] value)
-    (async/timeout 10000) (throw (ex-info "Take from channel timed out" {:channel channel}))))
+  (async/<!! channel))
 
 (defn make-ws-connection
   "Opens a connection and completes the auth handshake."


### PR DESCRIPTION
Tests should be deterministic. So we no longer rely on async timeouts in tests