### PR TITLE
Fix ci

### DIFF
--- a/src/time_tracker/timers/handlers.clj
+++ b/src/time_tracker/timers/handlers.clj
@@ -55,5 +55,11 @@
                                       :status         status})
                            (pubsub-state/remove-channel! channel)))
       (http-kit/on-receive channel (fn [data]
-                                     (pubsub/dispatch-command! channel
-                                                               (json/decode data keyword)))))))
+                                     (try
+                                       (log/debug {:event ::received-data
+                                                   :data  data})
+                                       (pubsub/dispatch-command! channel
+                                                                 (json/decode data keyword))
+                                       (catch Throwable e
+                                         (log/error e {:error ::websockets-error
+                                                       :data data}))))))))

--- a/src/time_tracker/timers/handlers.clj
+++ b/src/time_tracker/timers/handlers.clj
@@ -62,4 +62,8 @@
                                                                  (json/decode data keyword))
                                        (catch Throwable e
                                          (log/error e {:error ::websockets-error
-                                                       :data data}))))))))
+                                                       :data data})))))
+      ;; Send a "ready" message to the client to confirm
+      ;; that it can send message without them getting dropped.
+      ;; https://github.com/http-kit/http-kit/issues/318
+      (http-kit/send! channel (json/encode {:type "ready"})))))

--- a/src/time_tracker/timers/pubsub.clj
+++ b/src/time_tracker/timers/pubsub.clj
@@ -21,7 +21,6 @@
 (defn dispatch-command!
   "Calls the appropriate timer command."
   [channel command-data]
-  (log/debug (merge {:event ::received-data} command-data))
   (try
     (if-let [google-id (get @state/channel->google-id channel)]
       (if-let [command-fn (command-map (get command-data :command))]


### PR DESCRIPTION
This build fixes up CI failures which comes from https://github.com/http-kit/http-kit/issues/318.
Server now sends a "Ready frame" when the on-recive Callback hooks up after which messages can safely be sent by the Client.
Also adds better tracing, exception handling and logging