### PR TITLE
Removing hard-coded url

### DIFF
--- a/test/time_tracker/test_helpers.clj
+++ b/test/time_tracker/test_helpers.clj
@@ -50,7 +50,7 @@
   "Opens a connection and completes the auth handshake."
   [google-id]
   (let [response-chan (chan 5)
-        socket        (ws/connect "ws://localhost:8000/api/timers/ws-connect/"
+        socket        (ws/connect (settings :ws-url)
                                 :on-receive (fn on-receive
                                               [data]
                                               (log/debug {:event ::received-ws-data


### PR DESCRIPTION
We should no longer need hard-coded URLs in test