### PR TITLE
 Allow only invited users to use the app

### DIFF
--- a/resources/migrations/020-add-invited-user.down.sql
+++ b/resources/migrations/020-add-invited-user.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE invited_user;

--- a/resources/migrations/020-add-invited-user.up.sql
+++ b/resources/migrations/020-add-invited-user.up.sql
@@ -1,0 +1,5 @@
+CREATE TABLE invited_user (
+       email TEXT PRIMARY KEY,
+       invited_by INTEGER REFERENCES app_user(id),
+       registered BOOLEAN NOT NULL DEFAULT false
+);

--- a/resources/migrations/021-alter-app-user-add-col-email.down.sql
+++ b/resources/migrations/021-alter-app-user-add-col-email.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE app_user DROP COLUMN email;

--- a/resources/migrations/021-alter-app-user-add-col-email.up.sql
+++ b/resources/migrations/021-alter-app-user-add-col-email.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE app_user ADD COLUMN email TEXT;

--- a/src/time_tracker/core.clj
+++ b/src/time_tracker/core.clj
@@ -28,7 +28,6 @@
   (when-not (nil? @server)
     (@server :timeout 100)
     (log/info {:event ::server-stop})
-    (teardown!)
     (reset! server nil)))
 
 (defn restart-server!

--- a/src/time_tracker/invited_users/db.clj
+++ b/src/time_tracker/invited_users/db.clj
@@ -1,0 +1,19 @@
+(ns time-tracker.invited-users.db
+  (:require [yesql.core :refer [defqueries]]
+            [time-tracker.util :as util]
+            [clojure.java.jdbc :as jdbc]))
+
+(defqueries "time_tracker/invited_users/sql/db.sql")
+
+(defn create!
+  [connection email invited-by]
+  (create-invited-user-query<! {:email email
+                                :invited_by invited-by}
+                               {:connection connection}))
+
+(defn invited-email?
+  [connection email]
+  (= email (-> (retrieve-invited-user-query {:email email}
+                                            {:connection connection})
+               first
+               :email)))

--- a/src/time_tracker/invited_users/handlers.clj
+++ b/src/time_tracker/invited_users/handlers.clj
@@ -1,0 +1,15 @@
+(ns time-tracker.invited-users.handlers
+  (:require [time-tracker.invited-users.db :as invited-users-db]
+            [time-tracker.users.db :as users-db]
+            [time-tracker.web.util :as web-util]
+            [ring.util.response :as res]))
+
+(defn create
+  [{:keys [body credentials] :as request} connection]
+  (let [{:keys [email]} body
+        google-id (:sub credentials)
+        invited-by (users-db/retrieve connection google-id)]
+    (if (users-db/has-user-role? google-id connection ["admin"])
+      (let [invited-user (invited-users-db/create! connection email (:id invited-by))]
+        (res/response invited-user))
+      web-util/error-forbidden)))

--- a/src/time_tracker/invited_users/routes.clj
+++ b/src/time_tracker/invited_users/routes.clj
@@ -1,0 +1,8 @@
+(ns time-tracker.invited-users.routes
+  (:require [time-tracker.invited-users.handlers :as handlers]
+            [time-tracker.web.middleware :refer [with-rest-middleware]]))
+
+(defn routes []
+  {""        (with-rest-middleware
+               {;; :get  handlers/list-all
+                :post handlers/create})})

--- a/src/time_tracker/invited_users/sql/db.sql
+++ b/src/time_tracker/invited_users/sql/db.sql
@@ -1,0 +1,17 @@
+-- name: create-invited-user-query<!
+-- Inserts an invited user in the database.
+INSERT INTO invited_user
+(email, invited_by)
+VALUES (:email, :invited_by)
+ON CONFLICT DO NOTHING;
+
+-- name: retrieve-invited-user-query
+-- Retrieves an invited user
+SELECT * FROM invited_user
+WHERE invited_user.email = :email AND invited_user.registered = false
+LIMIT 1;
+
+-- name: mark-registered-user-query!
+-- Marks invited user as registered
+UPDATE invited_user SET registered = true
+WHERE invited_user.email = :email;

--- a/src/time_tracker/projects/routes.clj
+++ b/src/time_tracker/projects/routes.clj
@@ -4,16 +4,13 @@
             [clojure.algo.generic.functor :refer [fmap]]
             [clojure.java.jdbc :as jdbc]
             [time-tracker.db :refer [wrap-transaction]]
-            [time-tracker.users.core :refer [wrap-autoregister]]))
+            [time-tracker.web.middleware :refer [with-rest-middleware]]))
 
-(def middleware (comp wrap-auth wrap-transaction wrap-autoregister))
 
 (defn routes []
-  {[:id "/"] (fmap middleware
-                   {:get    handlers/retrieve
-                    :put    handlers/modify
-                    :delete handlers/delete})
-   ""        (fmap middleware
-                   {:get  handlers/list-all
-                    :post handlers/create})})
+  {[:id "/"] (with-rest-middleware {:get    handlers/retrieve
+                                    :put    handlers/modify
+                                    :delete handlers/delete})
+   ""        (with-rest-middleware {:get  handlers/list-all
+                                    :post handlers/create})})
 

--- a/src/time_tracker/timers/routes.clj
+++ b/src/time_tracker/timers/routes.clj
@@ -2,12 +2,9 @@
   (:require [time-tracker.timers.handlers :as handlers]
             [time-tracker.auth.core :refer [wrap-auth]]
             [time-tracker.db :refer [wrap-transaction]]
-            [time-tracker.users.core :refer [wrap-autoregister]]
+            [time-tracker.web.middleware :refer [with-rest-middleware]]
             [clojure.algo.generic.functor :refer [fmap]]))
-
-(def middleware (comp wrap-auth wrap-transaction wrap-autoregister))
 
 (defn routes []
   {"ws-connect/" handlers/ws-handler
-   ""            (fmap middleware
-                       {:get handlers/list-all})})
+   ""            (with-rest-middleware {:get handlers/list-all})})

--- a/src/time_tracker/users/core.clj
+++ b/src/time_tracker/users/core.clj
@@ -1,10 +1,20 @@
 (ns time-tracker.users.core
-  (:require [time-tracker.users.db :as users-db]))
+  (:require [time-tracker.users.db :as users-db]
+            [time-tracker.invited-users.db :as invited-users-db]
+            [time-tracker.web.util :as web-util]))
 
 (defn wrap-autoregister
   [handler]
   (fn [{:keys [credentials] :as request} connection]
-    (let [google-id (:sub credentials)
-          name      (:name credentials)]
-      (users-db/create! connection google-id name)
-      (handler request connection))))
+    (let [google-id   (:sub credentials)
+          email       (:email credentials)
+          invited?    (invited-users-db/invited-email? connection email)
+          registered? (users-db/registered? connection google-id)
+          username    (:name credentials)]
+      (cond
+        registered? (handler request connection)
+        invited?    (do (users-db/create! connection google-id username email)
+                        (invited-users-db/mark-registered-user-query! {:email email}
+                                                                      {:connection connection})
+                        (handler request connection))
+        :else       web-util/error-forbidden))))

--- a/src/time_tracker/users/db.clj
+++ b/src/time_tracker/users/db.clj
@@ -9,11 +9,12 @@
 (defn create!
   "Puts a user's details into the DB. The default role is 'user'.
   Does nothing if the user is already registered."
-  [connection google-id name]
+  [connection google-id name email]
   (when-let [created-user (create-user-query<! {:google_id google-id
-                                                :name      name}
+                                                :name      name
+                                                :email     email}
                                                {:connection  connection})]
-      (util/transform-keys created-user util/hyphenize)))
+    (util/transform-keys created-user util/hyphenize)))
 
 (defn registered?
   "Check if a user is in the DB"
@@ -36,7 +37,7 @@
 
 (defn has-user-role?
   [google-id connection roles]
-  (let [predicate (comp statement-success? :count first)]
+  (let [predicate (comp util/statement-success? :count first)]
     (some predicate
           (map (fn [role]
                  (has-role-query {:google_id google-id

--- a/src/time_tracker/users/handlers.clj
+++ b/src/time_tracker/users/handlers.clj
@@ -1,6 +1,7 @@
 (ns time-tracker.users.handlers
   (:require [ring.util.response :as res]
             [time-tracker.users.db :as users-db]
+            [time-tracker.invited-users.db :as invited-users-db]
             [time-tracker.web.util :as web-util]))
 
 ;; /users/me/

--- a/src/time_tracker/users/routes.clj
+++ b/src/time_tracker/users/routes.clj
@@ -1,7 +1,8 @@
 (ns time-tracker.users.routes
   (:require [time-tracker.users.handlers :as handlers]
-            [time-tracker.web.middleware :refer [with-rest-middleware]]))
+            [time-tracker.web.middleware :refer [rest-middleware
+                                                 with-rest-middleware]]))
 
 (defn routes []
   {"me/" (with-rest-middleware {:get handlers/retrieve})
-   ""    (with-rest-middleware {:get handlers/list-all})})
+   ""    {:get (rest-middleware handlers/list-all)}})

--- a/src/time_tracker/users/sql/db.sql
+++ b/src/time_tracker/users/sql/db.sql
@@ -11,8 +11,8 @@ SELECT * FROM app_user;
 -- name: create-user-query<!
 -- Inserts a user in the database.
 INSERT INTO app_user
-(google_id, name)
-VALUES (:google_id, :name)
+(google_id, name, email)
+VALUES (:google_id, :name, :email)
 ON CONFLICT DO NOTHING;
 
 -- name: has-role-query

--- a/src/time_tracker/web/middleware.clj
+++ b/src/time_tracker/web/middleware.clj
@@ -6,7 +6,7 @@
             [time-tracker.web.util :as web-util]
             [time-tracker.logging :as log]
             [cheshire.generate :refer [add-encoder encode-str]])
-    (:import org.httpkit.server.AsyncChannel))
+  (:import org.httpkit.server.AsyncChannel))
 
 (def rest-middleware
   (comp wrap-auth wrap-transaction wrap-autoregister))

--- a/src/time_tracker/web/routes.clj
+++ b/src/time_tracker/web/routes.clj
@@ -3,15 +3,17 @@
             [time-tracker.projects.routes :as projects]
             [time-tracker.timers.routes :as timers]
             [time-tracker.users.routes :as users]
+            [time-tracker.invited-users.routes :as invited-users]
             [time-tracker.tasks.routes :as tasks]
             [time-tracker.invoices.routes :as invoices]
             [time-tracker.web.util :as web-util]))
 
 (defn routes []
-  ["/" [["api/"      {"projects/" (projects/routes)
-                      "timers/"   (timers/routes)
-                      "users/"    (users/routes)
-                      "invoices/" (invoices/routes)
-                      "clients/"  (clients/routes)
-                      "tasks/" (tasks/routes)}]
+  ["/" [["api/"      {"projects/"      (projects/routes)
+                      "timers/"        (timers/routes)
+                      "users/"         (users/routes)
+                      "invited-users/" (invited-users/routes)
+                      "invoices/"      (invoices/routes)
+                      "clients/"       (clients/routes)
+                      "tasks/"         (tasks/routes)}]
         [true   (fn [_] web-util/error-not-found)]]])

--- a/test/time_tracker/clients/functional_test.clj
+++ b/test/time_tracker/clients/functional_test.clj
@@ -37,8 +37,8 @@
         (is (= expected actual))))))
 
 (deftest create-client-test
-  (user-helpers/create-users! ["Sai Abdul" "gid1" "admin"])
-  (user-helpers/create-users! ["Paul Graham" "gid2" "user"])
+  (user-helpers/create-users! ["Sai Abdul" "gid1" "admin" "sai@abdul.com"])
+  (user-helpers/create-users! ["Paul Graham" "gid2" "user" "pg@ycombinator.com"])
   (let [client {"name"              "Client1"
                 "address"           "High Road"
                 "gstin"             "MEDONTHAVEONE!!"
@@ -79,7 +79,7 @@
         (is (= 403 status))))))
 
 (deftest update-client-test
-  (user-helpers/create-users! ["Sai Abdul" "gid1" "admin"])
+  (user-helpers/create-users! ["Sai Abdul" "gid1" "admin" "sai@abdul.com"])
   (let [client                {"name"    "Client1"
                                "address" "High Road"
                                "gstin"   "MEDONTHAVEONE!!"

--- a/test/time_tracker/invoices/functional_test.clj
+++ b/test/time_tracker/invoices/functional_test.clj
@@ -35,63 +35,63 @@
 
 (comment
   (deftest create-and-download-invoice-test
-           (let [project-url           (s/join [(test-helpers/settings :api-root) "projects/"])
-                 invoice-url           (s/join [(test-helpers/settings :api-root) "invoices/"])
-                 users-url             (s/join [(test-helpers/settings :api-root) "users/"])
-                 _                     (users-helpers/create-users! ["sandy" "gid1" "admin"]
-                                                                    ["quux" "gid2" "admin"])
-                 _                     (test-helpers/http-request :post project-url "gid1"
-                                                                  {:name "bar|baz"})
-                 {users-body :body}    (test-helpers/http-request :get users-url "gid1")
-                 user-ids              (set (map #(get % "id") users-body))
-                 {:keys [status body]} (test-helpers/http-request :post project-url "gid1"
-                                                                  {:name "foo|goo"})
-                 project-id            (get body "id")
-                 current-time          (util/current-epoch-seconds)
-                 [ws-chan socket]      (test-helpers/make-ws-connection "gid1")
-                 created-timer         (create-timer-over-ws ws-chan socket
-                                                             project-id current-time
-                                                             3600)]
-             (try
-               (testing "Existing client"
-                 (let [data             {:client "foo"
-                                         :start (- current-time (* 60 60 24))
-                                         :end (+ current-time (* 60 60 24))
-                                         :address "baz"
-                                         :notes "quux"
-                                         :user-rates (vec (for [user-id user-ids]
-                                                            {:user-id user-id
-                                                             :rate    5}))
-                                         :utc-offset 330
-                                         :currency :inr
-                                         :tax-rates nil}
-                       {:keys [status]} (test-helpers/http-request-raw
-                                         :post
-                                         invoice-url
-                                         "gid1"
-                                         data)]
-                   (is (= 200 status))))
+    (let [project-url           (s/join [(test-helpers/settings :api-root) "projects/"])
+          invoice-url           (s/join [(test-helpers/settings :api-root) "invoices/"])
+          users-url             (s/join [(test-helpers/settings :api-root) "users/"])
+          _                     (users-helpers/create-users! ["sandy" "gid1" "admin" "sandy@sandy.com"]
+                                                             ["quux" "gid2" "admin" "quux@quux.com"])
+          _                     (test-helpers/http-request :post project-url "gid1"
+                                                           {:name "bar|baz"})
+          {users-body :body}    (test-helpers/http-request :get users-url "gid1")
+          user-ids              (set (map #(get % "id") users-body))
+          {:keys [status body]} (test-helpers/http-request :post project-url "gid1"
+                                                           {:name "foo|goo"})
+          project-id            (get body "id")
+          current-time          (util/current-epoch-seconds)
+          [ws-chan socket]      (test-helpers/make-ws-connection "gid1")
+          created-timer         (create-timer-over-ws ws-chan socket
+                                                      project-id current-time
+                                                      3600)]
+      (try
+        (testing "Existing client"
+          (let [data             {:client "foo"
+                                  :start (- current-time (* 60 60 24))
+                                  :end (+ current-time (* 60 60 24))
+                                  :address "baz"
+                                  :notes "quux"
+                                  :user-rates (vec (for [user-id user-ids]
+                                                     {:user-id user-id
+                                                      :rate    5}))
+                                  :utc-offset 330
+                                  :currency :inr
+                                  :tax-rates nil}
+                {:keys [status]} (test-helpers/http-request-raw
+                                  :post
+                                  invoice-url
+                                  "gid1"
+                                  data)]
+            (is (= 200 status))))
 
-               (testing "Another client with no timers"
-                 (let [data                  {:client "bar"
-                                              :start (- current-time (* 60 60 24))
-                                              :end (+ current-time (* 60 60 24))
-                                              :address "baz"
-                                              :notes "quux"
-                                              :user-rates (vec (for [user-id user-ids]
-                                                                 {:user-id user-id
-                                                                  :rate    5}))
-                                              :utc-offset 330
-                                              :currency :inr
-                                              :tax-rates nil}
-                       {:keys [status body]} (test-helpers/http-request-raw
-                                              :post
-                                              invoice-url
-                                              "gid1"
-                                              data)]
-                   (is (= 404 status))))
+        (testing "Another client with no timers"
+          (let [data                  {:client "bar"
+                                       :start (- current-time (* 60 60 24))
+                                       :end (+ current-time (* 60 60 24))
+                                       :address "baz"
+                                       :notes "quux"
+                                       :user-rates (vec (for [user-id user-ids]
+                                                          {:user-id user-id
+                                                           :rate    5}))
+                                       :utc-offset 330
+                                       :currency :inr
+                                       :tax-rates nil}
+                {:keys [status body]} (test-helpers/http-request-raw
+                                       :post
+                                       invoice-url
+                                       "gid1"
+                                       data)]
+            (is (= 404 status))))
 
-               (finally (ws/close socket)))))
+        (finally (ws/close socket)))))
 
   (deftest update-invoice-paid-test
     (let [invoices-url           (s/join [(test-helpers/settings :api-root) "invoices/"])

--- a/test/time_tracker/projects/db_test.clj
+++ b/test/time_tracker/projects/db_test.clj
@@ -80,7 +80,7 @@
                (sort project-names)))))))
 
 (deftest create-test
-  (users.helpers/create-users! ["Sai Abdul" "gid1" "admin"]
+  (users.helpers/create-users! ["Sai Abdul" "gid1" "admin" "sai@sai.com"]
                                ["Paul Graham" "gid2" "user"])
   (let [client-id (:id (clients.helpers/create-client! (db/connection) {:name "FooClient"}))
         created-project (projects.db/create!

--- a/test/time_tracker/projects/functional_test.clj
+++ b/test/time_tracker/projects/functional_test.clj
@@ -103,8 +103,8 @@
 
 
 (deftest create-project-test
-  (users.helpers/create-users! ["Sai Abdul" "gid1" "admin"]
-                               ["Paul Graham" "gid2" "user"])
+  (users.helpers/create-users! ["Sai Abdul" "gid1" "admin" "sai@abdul.com"]
+                               ["Paul Graham" "gid2" "user" "pg@pg.com"])
   (let [url (projects-api)
         client-id (:id (clients.helpers/create-client! (db/connection) {:name "FooClient"}))]
 

--- a/test/time_tracker/users/core_test.clj
+++ b/test/time_tracker/users/core_test.clj
@@ -3,7 +3,9 @@
             [time-tracker.users.core :as users-core]
             [clojure.java.jdbc :as jdbc]
             [time-tracker.db :as db]
-            [time-tracker.fixtures :as fixtures]))
+            [time-tracker.fixtures :as fixtures]
+            [time-tracker.users.db :as users-db]
+            [time-tracker.invited-users.db :as invited-users-db]))
 
 (use-fixtures :once fixtures/init! fixtures/migrate-test-db)
 (use-fixtures :each fixtures/isolate-db)
@@ -12,14 +14,60 @@
 (deftest wrap-autoregister-test
   (let [handler         (fn [request connection] request)
         wrapped-handler (users-core/wrap-autoregister handler)]
-    (testing "User does not exist"
-      (let [fake-request {:credentials {:sub  "gid1"
-                                        :name "dondochakka"}}
+    (testing "User is registered"
+      (let [gid "reg_gid"
+            username "reg_user"
+            email "reguser@reguser.com"]
+        (users-db/create! (db/connection) gid username email)
+        (let [fake-request {:credentials {:sub  gid
+                                          :name username
+                                          :email email}}
+              response     (wrapped-handler fake-request (db/connection))]
+          (is (= fake-request response)))))
+
+    (testing "User is invited"
+      (let [gid "inv_gid"
+            username "inv_user"
+            email "invuser@invuser.com"]
+        (invited-users-db/create! (db/connection) email 1)
+        (let [fake-request {:credentials {:sub  gid
+                                          :name username
+                                          :email email}}
+              response     (wrapped-handler fake-request (db/connection))
+              db-row       (jdbc/get-by-id (db/connection) "app_user" gid "google_id")
+              invited-user-db-row (jdbc/get-by-id (db/connection) "invited_user" email "email")]
+          (is (= gid (:google_id db-row)))
+          (is (= username (:name db-row)))
+          (is (= email (:email db-row)))
+
+          (is (= true (:registered invited-user-db-row)))
+          (is (= fake-request response)))))
+
+
+    (testing "User is not invited and not registered"
+      (let [gid "uninv_gid"
+            username "uninv_user"
+            email "uninvuser@uninvuser.com"
+            fake-request {:credentials {:sub  gid
+                                        :name username
+                                        :email email}}
             response     (wrapped-handler fake-request (db/connection))
-            db-row       (jdbc/get-by-id (db/connection) "app_user" "gid1" "google_id")]
-        (is (= "gid1"
-               (:google_id db-row)))
-        (is (= "dondochakka"
-               (:name db-row)))
-        (is (= fake-request
-               response))))))
+            db-row       (jdbc/get-by-id (db/connection) "app_user" gid "google_id")]
+        (is (= db-row nil))
+        (is (= 403 (:status response)))))
+
+
+
+
+    #_(testing "User does not exist"
+        (let [fake-request {:credentials {:sub  "gid1"
+                                          :name "dondochakka"}}
+              response     (wrapped-handler fake-request (db/connection))
+              db-row       (jdbc/get-by-id (db/connection) "app_user" "gid1" "google_id")]
+          (is (= "gid1"
+                 (:google_id db-row)))
+          (is (= "dondochakka"
+                 (:name db-row)))
+          (is (= fake-request
+                 response))))
+    ))

--- a/test/time_tracker/users/db_test.clj
+++ b/test/time_tracker/users/db_test.clj
@@ -11,20 +11,20 @@
 (use-fixtures :each fixtures/isolate-db)
 
 (deftest create-test
-  (let [created-user (users-db/create! (db/connection) "gid1" "sandy")
-        second-call  (users-db/create! (db/connection) "gid1" "sandy")]
+  (let [created-user (users-db/create! (db/connection) "gid1" "sandy" "foo@foo.com")
+        second-call  (users-db/create! (db/connection) "gid1" "sandy" "foo@foo.com")]
     (is (s/valid? ::users-spec/user created-user))
     (is (nil? second-call))))
 
 (deftest retrieve-all-test
-  (users-test-helpers/create-users! ["sandy" "gid1" "user"]
-                                    ["sandy2" "gid2" "user"]
-                                    ["sandy3" "gid3" "user"])
+  (users-test-helpers/create-users! ["sandy" "gid1" "user" "sandy@nilenso.com"]
+                                    ["sandy2" "gid2" "user" "sandy2@nilenso.com"]
+                                    ["sandy3" "gid3" "user" "sandy3@nilenso.com"])
   (let [users (users-db/retrieve-all (db/connection))]
     (testing "All users in the database should be retrieved"
       (is (= #{"gid1" "gid2" "gid3"}
              (set (map :google-id users)))))
     (testing "All fields should be retrieved"
       (doseq [user users]
-        (is (= #{:id :google-id :name :role}
+        (is (= #{:id :google-id :name :role :email}
                (set (keys user))))))))

--- a/test/time_tracker/users/functional_test.clj
+++ b/test/time_tracker/users/functional_test.clj
@@ -21,8 +21,8 @@
     (is (= "user" (get body "role")))))
 
 (deftest retrieve-all-users-test
-  (users-helpers/create-users! ["sandy" "gid1" "admin"]
-                               ["shaaz" "gid2" "user"])
+  (users-helpers/create-users! ["sandy" "gid1" "admin" "sandy@sandy.com"]
+                               ["shaaz" "gid2" "user" "shaaz@shaaz.com"])
   (testing "All the users in the database should appear in the response"
     (let [url (users-api)
           {:keys [status body]} (test-helpers/http-request :get url "gid1")]

--- a/test/time_tracker/users/test_helpers.clj
+++ b/test/time_tracker/users/test_helpers.clj
@@ -10,7 +10,7 @@
   ;; yesql can run batch statements.
   (jdbc/execute! (db/connection)
                  (into [(str "INSERT INTO app_user "
-                             "(name, google_id, role) "
-                             "VALUES (?, ?, ?::user_role);")]
+                             "(name, google_id, role, email) "
+                             "VALUES (?, ?, ?::user_role, ?);")]
                        args)
                  {:multi? true}))


### PR DESCRIPTION
- Add `POST /api/invited_users/` endpoint where an admin can invite(whitelist) an email
- Once an invited user logs in for the first time, the user is added to the `app_user` table and the row in `invited_user` table is marked as registered