### PR TITLE
Serve frontend assets from the backend server

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,8 @@
                  [org.clojure/tools.cli "1.0.194"]
                  [org.clojure/data.csv "0.1.3"]
                  [aero "1.1.6"]
-                 [log4j "1.2.17"]
+                 [org.apache.logging.log4j/log4j-api "2.13.3"]
+                 [org.apache.logging.log4j/log4j-core "2.13.3"]
                  [org.clojure/java.jdbc "0.6.2-alpha3"]
                  [http-kit "2.3.0"]
                  [bidi "2.0.11"]
@@ -35,7 +36,7 @@
              :test {:jvm-opts ["-Xms512m" "-Xmx2g"]}
              :default [:base :system :user :provided :dev]
              :uberjar {:aot [#"time-tracker.*"]}}
-
+  :jvm-opts ["-Dclojure.tools.logging.factory=clojure.tools.logging.impl/log4j2-factory"]
   :aliases {"test"       ["test"]
             "migrate"    ["run" "-m" "time-tracker.migration/lein-migrate-db"]
             "rollback"   ["run" "-m" "time-tracker.migration/lein-rollback-db"]}

--- a/resources/log4j2.properties
+++ b/resources/log4j2.properties
@@ -1,0 +1,10 @@
+status = warn
+monitorInterval = 5
+
+appender.console.type = Console
+appender.console.name = STDOUT
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %date %level %logger %message%n%throwable
+
+rootLogger.level = info
+rootLogger.appenderRef.stdout.ref = STDOUT

--- a/src/clj/time_tracker/config.clj
+++ b/src/clj/time_tracker/config.clj
@@ -3,10 +3,12 @@
 
 (defonce ^:private cfg (atom nil))
 
-(defn init [config]
-  (reset! cfg
-          (aero/read-config (or config
-                                (clojure.java.io/resource "config.edn")))))
+(defn init
+  ([]
+   (init (clojure.java.io/resource "config.edn")))
+  ([config]
+   (reset! cfg (aero/read-config (or config
+                                     (clojure.java.io/resource "config.edn"))))))
 
 (defn get-config
   ([] @cfg)

--- a/src/clj/time_tracker/core.clj
+++ b/src/clj/time_tracker/core.clj
@@ -10,14 +10,12 @@
 
 (defonce server (atom nil))
 
-(defn init! [args]
-  (cli/init! args)
-  (config/init (:config-file (cli/opts)))
-  (log/configure-logging!)
-  (db/init-db!))
-
-(defn teardown! []
-  (log/teardown-logging!))
+(defn init!
+  ([]
+   (init! nil))
+  ([config-file]
+   (config/init config-file)
+   (db/init-db!)))
 
 (defn start-server!
   ([] (start-server! (web-service/app)))
@@ -38,9 +36,16 @@
   (stop-server!)
   (start-server!))
 
+(defn start-app!
+  "REPL convenience. Starts the whole app from scratch."
+  []
+  (init!)
+  (start-server!))
+
 (defn -main
   [& args]
-  (init! args)
+  (cli/init! args)
+  (init! (:config-file (cli/opts)))
   (let [opt (dissoc (cli/opts) :config-file)]
     (if (> (count opt) 1)
       (prn "too many opts passed")

--- a/src/clj/time_tracker/logging.clj
+++ b/src/clj/time_tracker/logging.clj
@@ -1,11 +1,6 @@
 (ns time-tracker.logging
   (:require [clojure.tools.logging :as log]
-            [cheshire.core :as json]
-            [time-tracker.config :as config])
-  (:import [org.apache.log4j Level
-            Logger
-            ConsoleAppender
-            PatternLayout]))
+            [cheshire.core :as json]))
 
 (defmacro trace
   [msg]
@@ -35,44 +30,3 @@
    `(log/fatal (json/encode ~msg)))
   ([throwable msg]
    `(log/fatal ~throwable (json/encode ~msg))))
-
-(def log-levels {"all"   Level/ALL
-                 "trace" Level/TRACE
-                 "debug" Level/DEBUG
-                 "info"  Level/INFO
-                 "warn"  Level/WARN
-                 "error" Level/ERROR
-                 "fatal" Level/FATAL
-                 "off"   Level/OFF})
-
-(defn- set-logger-level*
-  [^org.apache.log4j.Logger logger level]
-  {:pre [(log-levels level)]}
-  (.setLevel logger (log-levels level)))
-
-(defn set-root-logger-level!
-  "Sets the root logger to be at `level`."
-  [level]
-  (set-logger-level* (Logger/getRootLogger)
-                     level))
-
-(defn set-logger-level!
-  "Sets the specified `logger` to be at `level`."
-  [logger level]
-  (set-logger-level* (Logger/getLogger logger)
-                     level))
-
-(defn add-root-logger-appender!
-  [appender]
-  (.addAppender (Logger/getRootLogger) appender))
-
-(defn configure-logging!
-  ([]
-   (configure-logging! (config/get-config :app-log-level)))
-  ([level]
-   (set-root-logger-level! "error")
-   (set-logger-level! "time-tracker" level)
-   (add-root-logger-appender! (ConsoleAppender.))))
-
-(defn teardown-logging! []
-  (.removeAllAppenders (Logger/getRootLogger)))

--- a/src/clj/time_tracker/migration.clj
+++ b/src/clj/time_tracker/migration.clj
@@ -31,9 +31,7 @@
 ;; These are called by `lein migrate` and `lein rollback`.
 
 (defn lein-migrate-db []
-  (log/configure-logging! "info")
   (migrate-db))
 
 (defn lein-rollback-db []
-  (log/configure-logging! "info")
   (rollback-db))

--- a/src/clj/time_tracker/web/routes.clj
+++ b/src/clj/time_tracker/web/routes.clj
@@ -6,14 +6,17 @@
             [time-tracker.invited-users.routes :as invited-users]
             [time-tracker.tasks.routes :as tasks]
             [time-tracker.invoices.routes :as invoices]
-            [time-tracker.web.util :as web-util]))
+            [time-tracker.web.util :as web-util]
+            [ring.util.response :as response]))
 
 (defn routes []
-  ["/" [["api/"      {"projects/"      (projects/routes)
-                      "timers/"        (timers/routes)
-                      "users/"         (users/routes)
-                      "invited-users/" (invited-users/routes)
-                      "invoices/"      (invoices/routes)
-                      "clients/"       (clients/routes)
-                      "tasks/"         (tasks/routes)}]
-        [true   (fn [_] web-util/error-not-found)]]])
+  ["/" [["" (fn [_] (-> (response/resource-response "public/index.html")
+                        (response/content-type "text/html")))]
+        ["api/" {"projects/"      (projects/routes)
+                 "timers/"        (timers/routes)
+                 "users/"         (users/routes)
+                 "invited-users/" (invited-users/routes)
+                 "invoices/"      (invoices/routes)
+                 "clients/"       (clients/routes)
+                 "tasks/"         (tasks/routes)}]
+        [true (fn [_] web-util/error-not-found)]]])

--- a/src/clj/time_tracker/web/service.clj
+++ b/src/clj/time_tracker/web/service.clj
@@ -4,6 +4,9 @@
                                           wrap-json-body]]
             [ring.middleware.params :refer [wrap-params]]
             [ring.middleware.defaults :refer :all]
+            [ring.middleware.resource :refer [wrap-resource]]
+            [ring.middleware.content-type :refer [wrap-content-type]]
+            [ring.middleware.not-modified :refer [wrap-not-modified]]
             [time-tracker.web.routes :refer [routes]]
             [time-tracker.web.middleware :refer [wrap-validate
                                                  wrap-log-request-response
@@ -20,5 +23,8 @@
       (wrap-json-body {:keywords? true})
       (wrap-json-response)
       (wrap-params)
-      (wrap-defaults api-defaults)))
+      (wrap-defaults api-defaults)
+      (wrap-resource "public")
+      (wrap-content-type)
+      (wrap-not-modified)))
 

--- a/test/clj/time_tracker/fixtures.clj
+++ b/test/clj/time_tracker/fixtures.clj
@@ -1,22 +1,18 @@
 (ns time-tracker.fixtures
   (:require [clojure.java.jdbc :as jdbc]
-            [clojure.string :as str]
             [time-tracker.migration :refer [migrate-db]]
             [time-tracker.db :as db]
             [time-tracker.web.service :refer [app]]
             [time-tracker.auth.core :as auth]
             [time-tracker.test-helpers :as test-helpers]
             [time-tracker.auth.test-helpers :refer [fake-token->credentials]]
-            [time-tracker.core :as core]
-            [time-tracker.util :as util])
+            [time-tracker.core :as core])
   (:use org.httpkit.server))
 
 (defn init! [f]
-  (core/init! (if-let [test-config (System/getenv "TIME_TRACKER_TEST_CONFIG")]
-                ["" "-sf" test-config]
-                ["" "-s"]))
-  (f)
-  (core/teardown!))
+  (core/init! (when-let [test-config (System/getenv "TIME_TRACKER_TEST_CONFIG")]
+                test-config))
+  (f))
 
 (defn destroy-db []
   (jdbc/with-db-transaction [conn (db/connection)]


### PR DESCRIPTION
Also upgrades logging to use log4j2, as a stop-gap fix so that we can at least view errors during development.